### PR TITLE
Update ddev get to use ddev/ddev-solr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![tests](https://github.com/mkalkbrenner/ddev-solr/actions/workflows/tests.yml/badge.svg)](https://github.com/mkalkbrenner/ddev-solr/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/ddev/ddev-solr/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-solr/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 
 # ddev-solr <!-- omit in toc -->
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ access rights:
 1. Install the addon
 
     ```shell
-    ddev get mkalkbrenner/ddev-solr
+    ddev get ddev/ddev-solr
     ```
 
 1. Restart DDEV to start the addon.


### PR DESCRIPTION
## The Issue

Updates `ddev get mkalkbrenner/ddev-solr` to `ddev get ddev/ddev-solr`, see #17.

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

