### PR TITLE
feat: enable HTTPS support, fixes #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ access rights:
    ```
 
 Once up and running, access Solr's admin UI within your browser by opening
-`http://<projectname>.ddev.site:8983`. For example, if the project is named
-"myproject" the hostname will be `http://myproject.ddev.site:8983`.
+`https://<projectname>.ddev.site:8943`. For example, if the project is named
+"myproject" the hostname will be `https://myproject.ddev.site:8943`.
 
 The admin UI is protected by basic authentication. The preconfigured admin
 account in `security.json` is user `solr` using the password `SolrRocks`.

--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -2,7 +2,7 @@
 
 services:
   solr:
-    image: solr:9.6
+    build: ./solr
     container_name: ddev-${DDEV_SITENAME}-solr
     expose:
       - 8983
@@ -19,7 +19,7 @@ services:
       SOLR_AUTHENTICATION_OPTS: -Dbasicauth=solr:SolrRocks
       VIRTUAL_HOST: ${DDEV_HOSTNAME}
       HTTP_EXPOSE: 8983:8983
-      #HTTPS_EXPOSE: 8943:8983
+      HTTPS_EXPOSE: 8943:8983
     volumes:
       - .:/mnt/ddev_config
       - ./solr/lib:/opt/solr/modules/ddev/lib

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,0 +1,9 @@
+#ddev-generated
+FROM solr:9.6
+
+# Fix HTTPS redirect to HTTP which breaks URL for Solr Admin UI.
+# The reason for this problem is that Solr uses Jetty as a webserver.
+# Jetty has X-Forwarded- headers disabled by default, enable them here:
+USER root
+RUN sed -i '/<!-- Uncomment to enable handling of X-Forwarded- style headers/,/-->/c\<Call name="addCustomizer"><Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg></Call>' /opt/solr/server/etc/jetty.xml
+USER solr


### PR DESCRIPTION
## The Issue

- #27

## How This PR Solves The Issue

Enables `X-Forwarded-` headers in the Solr webserver (Jetty), making HTTP and HTTPS work.

I found the answer here https://serverfault.com/questions/618172/https-reverse-proxy-on-http-jetty

## Manual Testing Instructions

```
mkdir solr-test && cd solr-test
ddev config --auto
git clone https://github.com/ddev/ddev-solr
cd ddev-solr && git checkout 20240604_stasadev_solr_enable_https && cd ..
ddev get ddev-solr
ddev start

# And finally test HTTP and HTTPS

# should open HTTP
ddev launch :8983

# should open HTTPS
ddev launch :8943
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

