### PR TITLE
Introduce version setting through environment variable, fixes #44

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [Getting started](#getting-started)
 - [Create a collection](#create-a-collection)
 - [Solr command line client](#solr-command-line-client)
+- [Using alternate versions of Solr](#using-alternate-versions-of-solr)
 - [Add third party Solr modules and libraries](#add-third-party-solr-modules-and-libraries)
 - [Solarium](#solarium-php-client)
 - [Drupal and Search API Solr](#drupal-and-search-api-solr)
@@ -114,6 +115,7 @@ This addon defaults to installing a preferred version of the [docker Solr image]
 1. **Install the addon**: `ddev addon get ddev/ddev-solr`
 2. **Set the environment variable**: `ddev dotenv set .ddev/.env.solr --solr-base-image "solr:8.11"`
 3. **Restart ddev**: `ddev restart`
+4. **Confirm the new Solr version**: `ddev solr version` expect a value something like `8.11.4`
 
 
 ## Add third party Solr modules and libraries

--- a/README.md
+++ b/README.md
@@ -112,10 +112,25 @@ account.
 
 This addon defaults to installing a preferred version of the [docker Solr image](https://hub.docker.com/_/solr), but can be configured to use a different version via environment variable (`$SOLR_BASE_IMAGE`).  For example, if you would like to install the latest Solr 8.11.x, follow the steps below:
 
-1. **Install the addon**: `ddev addon get ddev/ddev-solr`
-2. **Set the environment variable**: `ddev dotenv set .ddev/.env.solr --solr-base-image "solr:8.11"`
-3. **Rebuild Solr**: `ddev debug rebuild -s solr`
-4. **Confirm the new Solr version**: `ddev solr version` expect a value something like `8.11.4`
+```bash
+export SOLR_IMAGE="solr:8.11"
+
+ddev addon get ddev/ddev-solr
+
+ddev dotenv set .ddev/.env.solr --solr-base-image="${SOLR_IMAGE}"
+
+# remove old solr volume (if this is downgrade)
+ddev stop
+docker volume rm ddev-$(ddev status -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.name')_solr
+
+# rebuild solr image (required step)
+ddev debug rebuild -s solr
+
+ddev restart
+
+# confirm the new Solr version (expect a value something like 8.11.4)
+ddev solr version
+```
 
 
 ## Add third party Solr modules and libraries

--- a/README.md
+++ b/README.md
@@ -113,11 +113,10 @@ account.
 This addon defaults to installing a preferred version of the [docker Solr image](https://hub.docker.com/_/solr), but can be configured to use a different version via environment variable (`$SOLR_BASE_IMAGE`).  For example, if you would like to install the latest Solr 8.11.x, follow the steps below:
 
 ```bash
-export SOLR_IMAGE="solr:8.11"
-
 ddev addon get ddev/ddev-solr
 
-ddev dotenv set .ddev/.env.solr --solr-base-image="${SOLR_IMAGE}"
+# Change image version as appropriate.
+ddev dotenv set .ddev/.env.solr --solr-base-image="solr:8.11"
 
 # remove old solr volume (if this is downgrade)
 ddev stop

--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ ddev solr-zk
 Both commands are preconfigured to connect as user `solr` which is the admin
 account.
 
+## Using alternate versions of Solr
+
+This addon defaults to installing a preferred version of the [docker Solr image](https://hub.docker.com/_/solr), but can be configured to use a different version via environment variable (`$SOLR_BASE_IMAGE`).  For example, if you would like to install the latest Solr 8.11.x, follow the steps below:
+
+1. **Install the addon**: `ddev addon get ddev/ddev-solr`
+2. **Set the environment variable**: `ddev dotenv set .ddev/.env.solr --solr-base-image "solr:8.11"`
+3. **Restart ddev**: `ddev restart`
+
+
 ## Add third party Solr modules and libraries
 
 Copy third party Solr modules and libraries jar files into `.ddev/solr/lib/`.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This addon defaults to installing a preferred version of the [docker Solr image]
 
 1. **Install the addon**: `ddev addon get ddev/ddev-solr`
 2. **Set the environment variable**: `ddev dotenv set .ddev/.env.solr --solr-base-image "solr:8.11"`
-3. **Restart ddev**: `ddev restart`
+3. **Rebuild Solr**: `ddev debug rebuild -s solr`
 4. **Confirm the new Solr version**: `ddev solr version` expect a value something like `8.11.4`
 
 

--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -2,7 +2,10 @@
 
 services:
   solr:
-    build: ./solr
+    build: 
+      context: ./solr
+      args:
+        SOLR_BASE_IMAGE: ${SOLR_BASE_IMAGE}
     container_name: ddev-${DDEV_SITENAME}-solr
     expose:
       - 8983

--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -5,7 +5,7 @@ services:
     build: 
       context: ./solr
       args:
-        SOLR_BASE_IMAGE: ${SOLR_BASE_IMAGE}
+        SOLR_BASE_IMAGE: ${SOLR_BASE_IMAGE:-solr:9.6}
     container_name: ddev-${DDEV_SITENAME}-solr
     expose:
       - 8983

--- a/install.yaml
+++ b/install.yaml
@@ -4,3 +4,5 @@ project_files:
 - commands/solr/
 - docker-compose.solr.yaml
 - solr/
+
+ddev_version_constraint: '>= v1.23.5'

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,5 +1,6 @@
 #ddev-generated
-FROM solr:9.6
+ARG SOLR_BASE_IMAGE="solr:9.6"
+FROM $SOLR_BASE_IMAGE
 
 # Fix HTTPS redirect to HTTP which breaks URL for Solr Admin UI.
 # The reason for this problem is that Solr uses Jetty as a webserver.

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,5 +1,5 @@
 #ddev-generated
-ARG SOLR_BASE_IMAGE="solr:9.6"
+ARG SOLR_BASE_IMAGE="scratch"
 FROM $SOLR_BASE_IMAGE
 
 # Fix HTTPS redirect to HTTP which breaks URL for Solr Admin UI.

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -65,3 +65,15 @@ teardown() {
   ddev restart >/dev/null
   health_checks
 }
+
+@test "install specific image versiob" {
+  set -eu -o pipefail
+  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
+  echo "# ddev addon get ddev/ddev-solr with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev addon get ddev/ddev-solr
+  ddev dotenv set .ddev/.env.solr --solr-base-image "solr:8.11.4"
+  ddev restart >/dev/null
+  health_checks
+  SOLR_VERSION=$(ddev solr version | tr -d '[:space:]')
+  [ "$SOLR_VERSION" = "8.11.4" ]
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -71,7 +71,7 @@ teardown() {
   cd "${TESTDIR}" || { printf "Unable to cd to %s\n" "${TESTDIR}" >&2; exit 1; }
 
   echo "# ddev addon get ddev/ddev-solr with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev addon get ddev/ddev-solr
+  ddev addon get ${DIR}
 
   # Define test cases: (image_version, expected version pattern)
   versions=(

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -94,10 +94,6 @@ teardown() {
     echo "🔄 Rebuilding Solr service..." >&3
     ddev debug rebuild -s solr || { echo "❌ Failed to rebuild Solr" >&2; exit 1; }
 
-    # Perform health checks
-    echo "🩺 Running health checks..." >&3
-    health_checks || { echo "❌ Health check failed for $solr_image" >&2; exit 1; }
-
     # Capture Solr version (extracting just the numeric version)
     SOLR_VERSION=$(ddev solr version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || { printf "Failed to get Solr version\n" >&2; exit 1; })
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -71,7 +71,7 @@ teardown() {
   cd "${TESTDIR}" || { printf "Unable to cd to %s\n" "${TESTDIR}" >&2; exit 1; }
 
   echo "# ddev addon get ddev/ddev-solr with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev addon get ${DIR}
+  ddev addon get ddev/ddev-solr
 
   # Define test cases: (image_version, expected version pattern)
   versions=(
@@ -85,17 +85,23 @@ teardown() {
     solr_image=$1
     expected_pattern=$2
 
-    echo "Testing with Solr base image: $solr_image" >&3
+    echo "⚡ Testing with Solr base image: $solr_image" >&3
 
     # Set the desired Solr version
     ddev dotenv set .ddev/.env.solr --solr-base-image "$solr_image"
-    ddev debug rebuild -s solr >/dev/null
-    health_checks
+
+    # Rebuild Solr service (without suppressing output)
+    echo "🔄 Rebuilding Solr service..." >&3
+    ddev debug rebuild -s solr || { echo "❌ Failed to rebuild Solr" >&2; exit 1; }
+
+    # Perform health checks
+    echo "🩺 Running health checks..." >&3
+    health_checks || { echo "❌ Health check failed for $solr_image" >&2; exit 1; }
 
     # Capture Solr version (extracting just the numeric version)
     SOLR_VERSION=$(ddev solr version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || { printf "Failed to get Solr version\n" >&2; exit 1; })
 
-    echo "Retrieved Solr version: '$SOLR_VERSION'" >&3
+    echo "🔍 Retrieved Solr version: '$SOLR_VERSION'" >&3
 
     # Validate version format using regex matching
     if ! [[ $SOLR_VERSION =~ $expected_pattern ]]; then

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -52,7 +52,7 @@ teardown() {
   set -eu -o pipefail
   cd ${TESTDIR}
   echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  ddev addon get ${DIR}
   ddev restart
   health_checks
 }
@@ -61,7 +61,7 @@ teardown() {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
   echo "# ddev get ddev/ddev-solr with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ddev/ddev-solr
+  ddev addon get ddev/ddev-solr
   ddev restart >/dev/null
   health_checks
 }
@@ -71,7 +71,7 @@ teardown() {
   cd "${TESTDIR}" || { printf "Unable to cd to %s\n" "${TESTDIR}" >&2; exit 1; }
 
   echo "# ddev addon get ddev/ddev-solr with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev addon get ddev/ddev-solr
+  ddev addon get ${DIR}
 
   # Define test cases: (image_version, expected version pattern)
   versions=(


### PR DESCRIPTION
## The Issue

There was a request in issue 
* #44 on how to change the version of Solr.  At the time there wasn't a clear way of accomplishing it.  In recent versions of ddev a means of passing environment variables into addons has been created, so with @rfay 's competent guidance I've set this addon up to utilize it.

## How This PR Solves The Issue

Introduce a SOLR_BASE_IMAGE environment variable that controls what solr image is installed.

Rendered README section: https://github.com/UltraBob/ddev-solr/tree/configurable-versions?tab=readme-ov-file#using-alternate-versions-of-solr

## Manual Testing Instructions

1. Install this version of the addon. `ddev add-on get https://github.com/UltraBob/ddev-solr/tarball/configurable-versions`
2. run `ddev dotenv set .ddev/.env.solr --solr-base-image "solr:8.11"`
3. `ddev restart`
4. confirm that the solr version installed is now 8.11.4 or whatever the current latest 8.11.x is.

## Automated Testing Overview

I'm sure this functionality could use some tests.  I do not have time to contribute them.

## Related Issue Link(s)

https://github.com/ddev/ddev-solr/issues/44#issuecomment-2623437416

## Release/Deployment Notes

I wonder if the README should also mention the info I gleaned from #44 that solr versions 8-10 should be supported by this addon.  I suppose that may not be evergreen information so I did not include it.  I also did not mention what version is installed by default because that would easily fall out of date.
