### PR TITLE
feat: add `solr-admin` command, fixes #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ access rights:
     ddev add-on get ddev/ddev-solr && ddev restart
     ```
 
-Once up and running, access Solr's admin UI within your browser by opening
-`https://<projectname>.ddev.site:8943`. For example, if the project is named
-"myproject" the hostname will be `https://myproject.ddev.site:8943`.
+Once up and running, access Solr's admin UI within your browser by using `ddev solr-admin` (`https://<projectname>.ddev.site:8943`).
 
 The admin UI is protected by basic authentication. The preconfigured admin
 account in `security.json` is user `solr` using the password `SolrRocks`.

--- a/commands/host/solr-admin
+++ b/commands/host/solr-admin
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+## #ddev-generated: If you want to edit and own this file, remove this line.
+## Description: Launch a browser with Solr Admin
+## Usage: solr-admin
+## Example: "ddev solr-admin"
+
+echo "Login using 'solr' user and 'SolrRocks' password"
+
+DDEV_SOLR_ADMIN_PORT=8983
+DDEV_SOLR_ADMIN_HTTPS_PORT=8943
+
+if [ ${DDEV_PRIMARY_URL%://*} = "http" ] || [ -n "${GITPOD_WORKSPACE_ID:-}" ] || [ "${CODESPACES:-}" = "true" ]; then
+    ddev launch :$DDEV_SOLR_ADMIN_PORT
+else
+    ddev launch :$DDEV_SOLR_ADMIN_HTTPS_PORT
+fi

--- a/install.yaml
+++ b/install.yaml
@@ -2,6 +2,7 @@ name: solr
 
 project_files:
 - commands/solr/
+- commands/host/solr-admin
 - docker-compose.solr.yaml
 - solr/
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -88,15 +88,20 @@ health_checks() {
   assert_success
   assert_output --partial "Solr Admin"
 
-  # Make sure the custom `ddev solr` command works
+  # Make sure `ddev solr` command works
   run ddev solr
   assert_success
   assert_output --partial "COMMAND"
 
-  # Make sure the custom `ddev solr-zk` command works
+  # Make sure `ddev solr-zk` command works
   run ddev solr-zk ls /
   assert_success
   assert_output --partial "security.json"
+
+  # Make sure `ddev solr-admin` command works
+  DDEV_DEBUG=true run ddev solr-admin
+  assert_success
+  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site:8943"
 }
 
 teardown() {


### PR DESCRIPTION
## The Issue

- #41

## How This PR Solves The Issue

Adds `ddev solr-admin` command.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-solr/tarball/20250423_stasadev_solr-admin
ddev restart
ddev solr-admin
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
