### PR TITLE
refactor: update commands, v1.24.3 constraint, remove web links

### DIFF
--- a/commands/solr/solr
+++ b/commands/solr/solr
@@ -1,3 +1,8 @@
-#!/bin/bash
-#ddev-generated
+#!/usr/bin/env bash
+
+## #ddev-generated: If you want to edit and own this file, remove this line.
+## Description: Run Solr CLI inside the solr container
+## Usage: solr
+## Example: "ddev solr"
+
 solr "$@"

--- a/commands/solr/solr-zk
+++ b/commands/solr/solr-zk
@@ -1,3 +1,8 @@
-#!/bin/bash
-#ddev-generated
+#!/usr/bin/env bash
+
+## #ddev-generated: If you want to edit and own this file, remove this line.
+## Description: Run Solr ZooKeeper inside the solr container
+## Usage: solr-zk
+## Example: "ddev solr-zk"
+
 solr zk -z localhost:9983 "$@"

--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -25,6 +25,7 @@ services:
       HTTPS_EXPOSE: 8943:8983
     volumes:
       - .:/mnt/ddev_config
+      - ddev-global-cache:/mnt/ddev-global-cache
       - ./solr/lib:/opt/solr/modules/ddev/lib
       - solr:/var/solr
     command: bash -c "set -eu;
@@ -46,10 +47,6 @@ services:
       "
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s localhost:8983/solr/"]
-
-  web:
-    links:
-      - solr:solr
 
 volumes:
   solr:

--- a/install.yaml
+++ b/install.yaml
@@ -5,4 +5,4 @@ project_files:
 - docker-compose.solr.yaml
 - solr/
 
-ddev_version_constraint: '>= v1.23.5'
+ddev_version_constraint: '>= v1.24.3'


### PR DESCRIPTION
## The Issue

Upstream `ddev-addon-template` has some changes.

## How This PR Solves The Issue

- Adds v1.24.3 version constraint.
- Uses `#!/usr/bin/env bash` instead of `#!/bin/bash` (more universal)
- Adds missing annotations to solr commands.
- Removes web links from `docker-compose.solr.yaml` (newer docker-compose doesn't need that).
- Adds `ddev-global-cache` for commands.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-solr/tarball/20250423_stasadev_commands
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
