### PR TITLE
refactor: make `command` more readable

### DIFF
--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -35,23 +35,26 @@ services:
       - ddev-global-cache:/mnt/ddev-global-cache
       - ./solr/lib:/opt/solr/modules/ddev/lib
       - solr:/var/solr
-    command: bash -c "set -eu;
-      docker-entrypoint.sh solr start -c -Dlog4j.configurationFile=/opt/solr/server/resources/log4j2-console.xml;
-      solr zk cp file:/mnt/ddev_config/solr/security.json zk:/security.json -z localhost:9983;
-      cd /mnt/ddev_config/solr/configsets;
-      for dir in */; do
-        dir=$${dir%/};
-        if [[ \"$$dir\" != \"*\" ]]; then
-          echo \"uploading configset $$dir\";
-          solr zk upconfig -n \"$$dir\" -d \"$$dir\" -z localhost:9983;
-          echo \"creating collection $$dir\";
-          solr create -c \"$$dir\" -n \"$$dir\" -shards 1 -replicationFactor 1 || true;
-        fi;
-      done;
-      cd -;
-      solr stop > /dev/null;
-      exec solr-foreground -c -Dlog4j.configurationFile=/opt/solr/server/resources/log4j2.xml;
-      "
+    command:
+      - bash
+      - -c
+      - |
+        set -eu -o pipefail
+        docker-entrypoint.sh solr start -c -Dlog4j.configurationFile=/opt/solr/server/resources/log4j2-console.xml
+        solr zk cp file:/mnt/ddev_config/solr/security.json zk:/security.json -z localhost:9983
+        cd /mnt/ddev_config/solr/configsets
+        for dir in */; do
+          dir="$${dir%/}"
+          if [[ "$$dir" != "*" ]]; then
+            echo "uploading configset $$dir"
+            solr zk upconfig -n "$$dir" -d "$$dir" -z localhost:9983
+            echo "creating collection $$dir"
+            solr create -c "$$dir" -n "$$dir" -shards 1 -replicationFactor 1 || true
+          fi
+        done
+        cd -
+        solr stop > /dev/null
+        exec solr-foreground -c -Dlog4j.configurationFile=/opt/solr/server/resources/log4j2.xml
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s localhost:8983/solr/"]
 


### PR DESCRIPTION
## The Issue

It can be difficult to read `command` with a lot of `\"` and  `;`

## How This PR Solves The Issue

Uses different syntax.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-solr/tarball/20250602_stasadev_command
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
