### PR TITLE
fix: add `image` to `docker-compose.solr.yaml` to use DDEV offline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,19 @@
 ## The Issue
 
-- #<issue number>
+- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER
 
 <!-- Provide a brief description of the issue. -->
 
 ## How This PR Solves The Issue
 
+<!-- Describe the key change(s) in this PR that address the issue above. -->
+
 ## Manual Testing Instructions
 
+<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
+
 ```bash
-ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>
+ddev add-on get https://github.com/ddev/ddev-solr/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
 ```
 

--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -1,6 +1,7 @@
 #ddev-generated
 services:
   solr:
+    image: ${SOLR_BASE_IMAGE:-solr:9.6}-${DDEV_SITENAME}-built
     build:
       dockerfile_inline: |
         ARG SOLR_BASE_IMAGE="scratch"


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev-addon-template/pull/81

## How This PR Solves The Issue

Pulls the `solr:9.6` image on `ddev start`, which fixes offline usage in Docker.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-solr/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
docker inspect solr:9.6
ddev poweroff

# go offline and start the project
ddev start
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
