### PR TITLE
Use new enforced position of -z flag in solr zk, fixes #66

### DIFF
--- a/commands/solr/solr-zk
+++ b/commands/solr/solr-zk
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 
 ## #ddev-generated: If you want to edit and own this file, remove this line.
-## Description: Run Solr ZooKeeper inside the solr container
-## Usage: solr-zk
-## Example: "ddev solr-zk"
+## Description: Run Solr ZooKeeper commands inside the solr container (Solr 8+)
+## Usage: solr-zk [zk-subcommand] [args]
+## Examples:
+##   ddev solr-zk ls /
+##   ddev solr-zk upconfig -n myconfig -d /path/to/configset
+##   ddev solr-zk downconfig -n myconfig -d ./outdir
+##   ddev solr-zk cp -r file:/local/conf zk:/configs/myconfig
 
-solr zk -z localhost:9983 "$@"
+exec solr zk "$@" -z localhost:9983


### PR DESCRIPTION
## The Issue

- #66 

The `ddev solr-zk` command was failing on solr:9.8+

## How This PR Solves The Issue


The `-z` argument was always supposed to be after the subcommand, but it was suddenly enforced in solr 9.8

## Manual Testing Instructions

```
ddev add-on get https://ddev/ddev-solr/tarball/20250824_zk
ddev dotenv set .ddev/.env.solr --solr-base-image="solr:9.8"
ddev restart
# Then try using `ddev solr-zk`



## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
