### PR TITLE
feat: Populate ddev describe with user/pass and base image, fixes #71

### DIFF
--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -62,6 +62,9 @@ services:
         exec solr-foreground -c -Dlog4j.configurationFile=/opt/solr/server/resources/log4j2.xml
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s localhost:8983/solr/"]
-
+    x-ddev:
+      describe-info: |
+        User/Pass: 'solr/SolrRocks'
+        Base Image: ${SOLR_BASE_IMAGE:-solr:9}
 volumes:
   solr:

--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -64,7 +64,9 @@ services:
       test: ["CMD-SHELL", "curl --fail -s localhost:8983/solr/"]
     x-ddev:
       describe-info: |
-        User/Pass: 'solr/SolrRocks'
-        Base Image: ${SOLR_BASE_IMAGE:-solr:9}
+        User: solr
+        Pass: SolrRocks
+        Image: ${SOLR_BASE_IMAGE:-solr:9}
+      ssh-shell: bash
 volumes:
   solr:

--- a/install.yaml
+++ b/install.yaml
@@ -20,4 +20,4 @@ pre_install_actions:
       fi
     fi
 
-ddev_version_constraint: '>= v1.24.9'
+ddev_version_constraint: '>= v1.24.10'

--- a/install.yaml
+++ b/install.yaml
@@ -20,4 +20,4 @@ pre_install_actions:
       fi
     fi
 
-ddev_version_constraint: '>= v1.24.3'
+ddev_version_constraint: '>= v1.24.9'


### PR DESCRIPTION
## The Issue

- #71

Show description/user/pass/base image in ddev describe

<img width="1741" height="343" alt="image" src="https://github.com/user-attachments/assets/380df2ab-51b7-4322-9b01-1450a6370300" />

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-solr/tarball/refs/pull/73/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

* This was done as a demonstration of this new feature at TYPO3Camp RheinRuhr 2025 live in class :)
* Changed ddev_version_constraint to v1.24.10